### PR TITLE
Enhance Server with HTTP middleware support and API refinement

### DIFF
--- a/_examples/extensions/main.go
+++ b/_examples/extensions/main.go
@@ -176,8 +176,8 @@ func main() {
 		Agent: agent,
 	}
 
-	// Add extensions using the Use method
-	server.Use(dataOnlyExt, methodExt, profileExt)
+	// Add extensions using the AddExtension method
+	server.AddExtension(dataOnlyExt, methodExt, profileExt)
 
 	fmt.Println("🎯 Demo Server Configuration:")
 	fmt.Println("  • DataOnly Extension: Custom capabilities in AgentCard")


### PR DESCRIPTION
- Add HTTP middleware support with server.Use() method for standard HTTP middleware pattern
- Split Extension vs Middleware responsibilities:
  - server.AddExtension() for A2A Protocol extensions
  - server.Use() for HTTP middleware (compatible with Gorilla/mux pattern)
- Add custom endpoint registration with server.Handle/HandleFunc
- Implement middleware chain application with proper execution order
- Add comprehensive tests for middleware functionality and A2A compatibility
- Update examples to demonstrate new patterns

Key improvements:
- Clear separation between A2A Protocol extensions and HTTP middleware
- Standard Go HTTP middleware ecosystem compatibility
- Flexible observability hooks (OTel, metrics, logging)
- Backward-compatible API changes with clear migration path

🤖 Generated with Claude Code