### PR TITLE
Enhance Authenticator interface and extract base URL utility function

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -78,7 +78,7 @@ func (s StaticAPIKeyAuthenticator) Authenticate(ctx context.Context, r *http.Req
 }
 
 // GetSecuritySchemes implements the transport.Authenticator interface
-func (s StaticAPIKeyAuthenticator) GetSecuritySchemes() map[string]a2a.SecurityScheme {
+func (s StaticAPIKeyAuthenticator) GetSecuritySchemes(r *http.Request) map[string]a2a.SecurityScheme {
 	headerName := s.HeaderName
 	if headerName == "" {
 		headerName = "X-API-Key"
@@ -95,7 +95,7 @@ func (s StaticAPIKeyAuthenticator) GetSecuritySchemes() map[string]a2a.SecurityS
 }
 
 // GetSecurityRequirements implements the transport.Authenticator interface
-func (s StaticAPIKeyAuthenticator) GetSecurityRequirements() []map[string][]string {
+func (s StaticAPIKeyAuthenticator) GetSecurityRequirements(r *http.Request) []map[string][]string {
 	return []map[string][]string{
 		{"apiKey": {}}, // No specific scopes required for this simple example
 	}
@@ -254,7 +254,7 @@ func (j *JWTAuthenticator) Authenticate(ctx context.Context, r *http.Request) (*
 }
 
 // GetSecuritySchemes implements the transport.Authenticator interface
-func (j *JWTAuthenticator) GetSecuritySchemes() map[string]a2a.SecurityScheme {
+func (j *JWTAuthenticator) GetSecuritySchemes(r *http.Request) map[string]a2a.SecurityScheme {
 	return map[string]a2a.SecurityScheme{
 		"bearer": {
 			Type:         a2a.SecurityTypeHTTP,
@@ -266,7 +266,7 @@ func (j *JWTAuthenticator) GetSecuritySchemes() map[string]a2a.SecurityScheme {
 }
 
 // GetSecurityRequirements implements the transport.Authenticator interface
-func (j *JWTAuthenticator) GetSecurityRequirements() []map[string][]string {
+func (j *JWTAuthenticator) GetSecurityRequirements(r *http.Request) []map[string][]string {
 	return []map[string][]string{
 		{"bearer": {}}, // JWT validation handles scopes internally
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -2,6 +2,7 @@ package atlasic
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -102,7 +103,8 @@ func TestStaticAPIKeyAuthenticator_SecuritySchemes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			schemes := tt.auth.GetSecuritySchemes()
+			req := &http.Request{Header: make(http.Header)}
+			schemes := tt.auth.GetSecuritySchemes(req)
 
 			apiKeyScheme, exists := schemes["apiKey"]
 			if !exists {
@@ -294,7 +296,8 @@ func TestJWTAuthenticator_MissingBearer(t *testing.T) {
 
 func TestJWTAuthenticator_SecuritySchemes(t *testing.T) {
 	auth := NewJWTAuthenticator([]byte("secret"))
-	schemes := auth.GetSecuritySchemes()
+	req := &http.Request{Header: make(http.Header)}
+	schemes := auth.GetSecuritySchemes(req)
 
 	bearerScheme, exists := schemes["bearer"]
 	if !exists {

--- a/transport/authenticator.go
+++ b/transport/authenticator.go
@@ -16,11 +16,13 @@ type Authenticator interface {
 
 	// GetSecuritySchemes returns the security schemes supported by this authenticator
 	// This information is used to populate the AgentCard
-	GetSecuritySchemes() map[string]a2a.SecurityScheme
+	// The request parameter allows for request-specific scheme configuration
+	GetSecuritySchemes(r *http.Request) map[string]a2a.SecurityScheme
 
 	// GetSecurityRequirements returns the security requirements for this authenticator
 	// This information is used to populate the AgentCard
-	GetSecurityRequirements() []map[string][]string
+	// The request parameter allows for request-specific requirement configuration
+	GetSecurityRequirements(r *http.Request) []map[string][]string
 }
 
 // AuthError represents an authentication error


### PR DESCRIPTION
- Updated Authenticator interface to accept *http.Request in GetSecuritySchemes and GetSecurityRequirements methods
- Added ExtractBaseURL public utility function in transport package (renamed from buildRequestBaseEndpoint)
- Updated all Authenticator implementations (StaticAPIKeyAuthenticator, JWTAuthenticator) to use new interface
- Updated test files to pass request parameter to security scheme methods
- Added backward compatibility wrapper for buildRequestBaseEndpoint

🤖 Generated with [Claude Code](https://claude.ai/code)